### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/d0x7/protoc-gen-uuidhelper/security/code-scanning/1](https://github.com/d0x7/protoc-gen-uuidhelper/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only builds and tests the Go project, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents. This change adheres to the principle of least privilege and ensures the workflow has only the access it needs.

The `permissions` block will be added after the `name` field (line 4) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
