### PR TITLE
Add support for nested messages

### DIFF
--- a/internal/test/test.proto
+++ b/internal/test/test.proto
@@ -22,6 +22,20 @@ message Player {
     bytes v2_uuid = 7;
   }
 
+  // Nested UUID
+  message NestedMsg {
+    bytes nested_uuid = 1;
+  }
+  NestedMsg nested = 8;
+  optional NestedMsg optional_nested = 9;
+
   // Optional UUID
   optional bytes opt_uuid = 10;
+
+  Child child = 35;
+}
+
+message Child {
+  bytes child_uuid = 1;
+  repeated bytes child_uuids = 2;
 }

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -78,3 +78,17 @@ func TestOptionalUUID(t *testing.T) {
 		t.Fatalf("Optional UUID mismatch: expected %v, got %v", player.GetOptUUID(), newPlayer.GetOptUUID())
 	}
 }
+
+func TestNestedUUID(t *testing.T) {
+	player := &gen.Player{}
+
+	player.Nested = &gen.Player_NestedMsg{}
+	player.GetNested().SetNestedUUID(uuid.Must(uuid.NewRandom()))
+
+	newPlayer := transmit(t, player)
+
+	// Check if GetNestedUUID of both players are equal
+	if newPlayer.GetNested().GetNestedUUID() != player.GetNested().GetNestedUUID() {
+		t.Fatalf("Nested UUID mismatch: expected %v, got %v", player.GetNested().GetNestedUUID(), newPlayer.GetNested().GetNestedUUID())
+	}
+}


### PR DESCRIPTION
This makes embedded messages also check for UUID fields and thus have them generated, if present.

Closes #3.