### PR TITLE
feat: add support for map field types

### DIFF
--- a/cmd/protoc-gen-uuidhelper-kotlin/writer.go
+++ b/cmd/protoc-gen-uuidhelper-kotlin/writer.go
@@ -274,4 +274,9 @@ func (w *kotlinFileWriter) GenerateListField(msg *protogen.Message, field *proto
 	w.g.P()
 }
 
+func (w *kotlinFileWriter) GenerateMapField(msg *protogen.Message, field *protogen.Field) {
+	w.g.P("// Field '", field.Desc.Name(), "': Maps is not supported in Kotlin yet.")
+	w.g.P()
+}
+
 func (w *kotlinFileWriter) Close() {}

--- a/core/generator.go
+++ b/core/generator.go
@@ -23,6 +23,9 @@ type UUIDFileWriter interface {
 	// GenerateListField will be called for each repeated UUID field found in a message
 	GenerateListField(msg *protogen.Message, field *protogen.Field)
 
+	// GenerateMapField will be called for each map<key, bytes> field found in a message
+	GenerateMapField(msg *protogen.Message, field *protogen.Field)
+
 	// Close will be called after all UUIDs are handled; should return the generated file
 	Close()
 }

--- a/core/main.go
+++ b/core/main.go
@@ -37,6 +37,8 @@ func MainWithFlags(flags *flag.FlagSet, generator UUIDHelperBackend) {
 				writer.GenerateSingleField(msg, field)
 			} else if isUUIDsField(field) {
 				writer.GenerateListField(msg, field)
+			} else if isUUIDMap(field) {
+				writer.GenerateMapField(msg, field)
 			} else if isEmbeddedUUIDField(field) {
 				generateMessage(writer, field.Message)
 			}
@@ -94,6 +96,14 @@ func MainWithFlags(flags *flag.FlagSet, generator UUIDHelperBackend) {
 		}
 		return nil
 	})
+}
+
+func isUUIDMap(field *protogen.Field) bool {
+	return (strings.HasSuffix(string(field.Desc.Name()), "_uuid") ||
+		strings.HasSuffix(string(field.Desc.Name()), "_uuids")) &&
+		field.Desc.Kind() == protoreflect.MessageKind &&
+		field.Desc.IsMap() &&
+		field.Desc.MapValue().Kind() == protoreflect.BytesKind
 }
 
 func isEmbeddedUUIDField(field *protogen.Field) bool {

--- a/internal/test/test.proto
+++ b/internal/test/test.proto
@@ -32,10 +32,38 @@ message Player {
   // Optional UUID
   optional bytes opt_uuid = 10;
 
+  // Map UUIDs
+  map<int32, bytes> map_int32_uuid = 11;
+  map<int64, bytes> map_int64_uuid = 12;
+  map<uint32, bytes> map_uint32_uuid = 13;
+  map<uint64, bytes> map_uint64_uuid = 14;
+  map<sint32, bytes> map_sint32_uuid = 15;
+  map<sint64, bytes> map_sint64_uuid = 16;
+  map<fixed32, bytes> map_fixed32_uuid = 17;
+  map<fixed64, bytes> map_fixed64_uuid = 18;
+  map<sfixed32, bytes> map_sfixed32_uuid = 19;
+  map<sfixed64, bytes> map_sfixed64_uuid = 20;
+  map<bool, bytes> map_bool_uuid = 21;
+  map<string, bytes> map_string_uuid = 22;
+
+  map<int32, bytes> map_int32_uuids = 23;
+  map<int64, bytes> map_int64_uuids = 24;
+  map<uint32, bytes> map_uint32_uuids = 25;
+  map<uint64, bytes> map_uint64_uuids = 26;
+  map<sint32, bytes> map_sint32_uuids = 27;
+  map<sint64, bytes> map_sint64_uuids = 28;
+  map<fixed32, bytes> map_fixed32_uuids = 29;
+  map<fixed64, bytes> map_fixed64_uuids = 30;
+  map<sfixed32, bytes> map_sfixed32_uuids = 31;
+  map<sfixed64, bytes> map_sfixed64_uuids = 32;
+  map<bool, bytes> map_bool_uuids = 33;
+  map<string, bytes> map_string_uuids = 34;
+
   Child child = 35;
 }
 
 message Child {
   bytes child_uuid = 1;
   repeated bytes child_uuids = 2;
+  map<string, bytes> map_child_uuid = 3;
 }

--- a/internal/test/test_test.go
+++ b/internal/test/test_test.go
@@ -55,6 +55,29 @@ func TestUUIDs(t *testing.T) {
 	}
 }
 
+func TestMaps(t *testing.T) {
+	player := &gen.Player{}
+
+	player.GetMapStringUUIDs()
+	player.SetMapStringUUIDs(map[string]uuid.UUID{
+		"key1": uuid.Must(uuid.NewRandom()),
+		"key2": uuid.Must(uuid.NewRandom()),
+	})
+	player.GetMapStringUUIDs()
+
+	newPlayer := transmit(t, player)
+
+	// Check if GetMapStringUUIDs of both players are equal
+	if len(player.GetMapStringUUIDs()) != len(newPlayer.GetMapStringUUIDs()) {
+		t.Fatalf("Map UUIDs length mismatch: expected %d, got %d", len(player.GetMapStringUUIDs()), len(newPlayer.GetMapStringUUIDs()))
+	}
+	for k, v := range player.GetMapStringUUIDs() {
+		if newPlayer.GetMapStringUUIDs()[k] != v {
+			t.Fatalf("Map UUID mismatch at key %s: expected %v, got %v", k, v, newPlayer.GetMapStringUUIDs()[k])
+		}
+	}
+}
+
 func TestOptionalUUID(t *testing.T) {
 	player := &gen.Player{}
 


### PR DESCRIPTION
This adds support for generating fields which are maps using the uuid/uuids suffix and have the value type set to bytes. Key type is anything valid in protobuf.

This commit only implements the changes needed to the core itself aswell as the Go plugin, but not the Kotlin plugin, where it's currently not yet available.

Closes #6.